### PR TITLE
Fix form

### DIFF
--- a/bhp_personnel/admin/appraisal_admin.py
+++ b/bhp_personnel/admin/appraisal_admin.py
@@ -45,7 +45,7 @@ class AppraisalAdmin(ModelAdminMixin, admin.ModelAdmin):
 
     radio_fields = {
         'assessment_type': admin.VERTICAL, }
-
+    search_fields = ('emp_identifier', )
     def get_form(self, request, obj=None, **kwargs):
         form = super().get_form(request, obj, **kwargs)
         form.request = request

--- a/bhp_personnel/admin/contract_admin.py
+++ b/bhp_personnel/admin/contract_admin.py
@@ -50,7 +50,7 @@ class ContractAdmin(ModelAdminMixin, admin.ModelAdmin):
     list_filter = [
         'created', 'duration', 'start_date', 'end_date', 'status']
 
-    search_fields = ('contract',)
+    search_fields = ('identifier',)
 
     def has_change_permission(self, request, obj=None):
         if 'HR' in request.user.groups.values_list('name', flat=True):

--- a/bhp_personnel/admin/contracting_admin.py
+++ b/bhp_personnel/admin/contracting_admin.py
@@ -25,6 +25,3 @@ class ContractingAdmin(ModelAdminMixin, admin.ModelAdmin):
     search_fields = ('identifier', )
     autocomplete_fields = ['job_description', ]
 
-    """def get_readonly_fields(self, request, obj=None):
-        fields = super().get_readonly_fields(request, obj)
-        return ('contract', 'identifier', ) + fields"""

--- a/bhp_personnel/admin/contracting_admin.py
+++ b/bhp_personnel/admin/contracting_admin.py
@@ -22,5 +22,9 @@ class ContractingAdmin(ModelAdminMixin, admin.ModelAdmin):
 
     filter_horizontal = ('skills',)
     list_filter = ('job_description',)
+    search_fields = ('identifier', )
     autocomplete_fields = ['job_description', ]
 
+    """def get_readonly_fields(self, request, obj=None):
+        fields = super().get_readonly_fields(request, obj)
+        return ('contract', 'identifier', ) + fields"""

--- a/bhp_personnel/admin/contracting_admin.py
+++ b/bhp_personnel/admin/contracting_admin.py
@@ -25,3 +25,8 @@ class ContractingAdmin(ModelAdminMixin, admin.ModelAdmin):
     search_fields = ('identifier', )
     autocomplete_fields = ['job_description', ]
 
+    def get_form(self, request, obj=None, **kwargs):
+        form = super().get_form(request, obj, **kwargs)
+        form.request = request
+        return form
+

--- a/bhp_personnel/admin/contracting_admin.py
+++ b/bhp_personnel/admin/contracting_admin.py
@@ -24,6 +24,3 @@ class ContractingAdmin(ModelAdminMixin, admin.ModelAdmin):
     list_filter = ('job_description',)
     autocomplete_fields = ['job_description', ]
 
-    def get_readonly_fields(self, request, obj=None):
-        fields = super().get_readonly_fields(request, obj)
-        return ('contract', 'identifier', ) + fields

--- a/bhp_personnel/admin/renewal_intent_admin.py
+++ b/bhp_personnel/admin/renewal_intent_admin.py
@@ -30,6 +30,11 @@ class RenewalIntentAdmin(ModelAdminMixin, admin.ModelAdmin):
         "intent": admin.VERTICAL,
     }
 
+    def get_form(self, request, obj=None, **kwargs):
+        form = super().get_form(request, obj, **kwargs)
+        form.request = request
+        return form
+
 
 
 

--- a/bhp_personnel/forms/contracting_form.py
+++ b/bhp_personnel/forms/contracting_form.py
@@ -7,10 +7,10 @@ from ..models import Contracting
 
 class ContractingForm(SiteModelFormMixin, forms.ModelForm):
 
-    def __init___(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields['contract'].widget.attrs['readonly'] = True
-        self.fields['identifier'].widget.attrs['readonly'] = True
+        self.fields['contract'].disabled = True
+        self.fields['identifier'].disabled = True
 
     class Meta:
         model = Contracting

--- a/bhp_personnel/forms/contracting_form.py
+++ b/bhp_personnel/forms/contracting_form.py
@@ -18,3 +18,6 @@ class ContractingForm(SiteModelFormMixin, forms.ModelForm):
         if contract:
             self.fields['contract'].queryset = Contract.objects.filter(id=contract)
 
+    class Meta:
+        model = Contracting
+        fields = '__all__'

--- a/bhp_personnel/forms/contracting_form.py
+++ b/bhp_personnel/forms/contracting_form.py
@@ -6,13 +6,15 @@ from ..models import Contracting, Contract
 
 
 class ContractingForm(SiteModelFormMixin, forms.ModelForm):
-    contract = forms.ModelChoiceField(label='Contract', queryset=Contract.objects.all(),
-                                      widget=forms.TextInput(attrs={'readonly': 'readonly'}))
+    contract = forms.ModelChoiceField(
+        label='Contract',
+        queryset=Contract.objects.none(),
+    )
 
     def __init__(self, *args, **kwargs):
+        contract = self.request.GET.get('contract')
         super().__init__(*args, **kwargs)
         self.fields['identifier'].widget.attrs['readonly'] = True
+        if contract:
+            self.fields['contract'].queryset = Contract.objects.filter(id=contract)
 
-    class Meta:
-        model = Contracting
-        fields = '__all__'

--- a/bhp_personnel/forms/contracting_form.py
+++ b/bhp_personnel/forms/contracting_form.py
@@ -2,15 +2,16 @@ from django import forms
 
 from edc_base.sites import SiteModelFormMixin
 
-from ..models import Contracting
+from ..models import Contracting, Contract
 
 
 class ContractingForm(SiteModelFormMixin, forms.ModelForm):
+    contract = forms.ModelChoiceField(label='Contract', queryset=Contract.objects.all(),
+                                      widget=forms.TextInput(attrs={'readonly': 'readonly'}))
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields['contract'].disabled = True
-        self.fields['identifier'].disabled = True
+        self.fields['identifier'].widget.attrs['readonly'] = True
 
     class Meta:
         model = Contracting

--- a/bhp_personnel/forms/renewal_intent_form.py
+++ b/bhp_personnel/forms/renewal_intent_form.py
@@ -7,9 +7,9 @@ from ..models import RenewalIntent
 
 class RenewalIntentForm(SiteModelFormMixin, forms.ModelForm):
 
-    contract = forms.CharField(
-        label=' Contract',
-        widget=forms.TextInput(attrs={'readonly': 'readonly'}))
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['contract'].disabled = True
 
     class Meta:
         model = RenewalIntent

--- a/bhp_personnel/forms/renewal_intent_form.py
+++ b/bhp_personnel/forms/renewal_intent_form.py
@@ -2,14 +2,12 @@ from django import forms
 
 from edc_base.sites import SiteModelFormMixin
 
-from ..models import RenewalIntent
+from ..models import RenewalIntent, Contract
 
 
 class RenewalIntentForm(SiteModelFormMixin, forms.ModelForm):
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.fields['contract'].disabled = True
+    contract = forms.ModelChoiceField(label='Contract', queryset=Contract.objects.all(),
+                                      widget=forms.TextInput(attrs={'readonly': 'readonly'}))
 
     class Meta:
         model = RenewalIntent

--- a/bhp_personnel/forms/renewal_intent_form.py
+++ b/bhp_personnel/forms/renewal_intent_form.py
@@ -6,8 +6,16 @@ from ..models import RenewalIntent, Contract
 
 
 class RenewalIntentForm(SiteModelFormMixin, forms.ModelForm):
-    contract = forms.ModelChoiceField(label='Contract', queryset=Contract.objects.all(),
-                                      widget=forms.TextInput(attrs={'readonly': 'readonly'}))
+    contract = forms.ModelChoiceField(
+        label='Contract',
+        queryset=Contract.objects.none(),
+    )
+
+    def __init__(self, *args, **kwargs):
+        contract = self.request.GET.get('contract')
+        super().__init__(*args, **kwargs)
+        if contract:
+            self.fields['contract'].queryset = Contract.objects.filter(id=contract)
 
     class Meta:
         model = RenewalIntent


### PR DESCRIPTION
Setting the disabled attribute to True was preventing new forms from being saved, as it resulted in the fields being omitted from the POST method data. To address this issue, I have modified all 'contract' fields in the forms to use the readonly attribute instead of disabled, thereby ensuring they are included in the POST data and allowing new forms to be saved correctly.